### PR TITLE
Update misue of YYYY weekyear for calendar year yyyy.

### DIFF
--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/server/AuthenticationFilter.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/server/AuthenticationFilter.java
@@ -691,7 +691,7 @@ public class AuthenticationFilter implements Filter {
     if (expires >= 0 && isCookiePersistent) {
       Date date = new Date(expires);
       SimpleDateFormat df = new SimpleDateFormat("EEE, " +
-              "dd-MMM-YYYY HH:mm:ss zzz", Locale.US);
+              "dd-MMM-yyyy HH:mm:ss zzz", Locale.US);
       df.setTimeZone(TimeZone.getTimeZone("GMT"));
       sb.append("; Expires=").append(df.format(date));
     }

--- a/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/state/StatePool.java
+++ b/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/state/StatePool.java
@@ -173,7 +173,7 @@ public class StatePool {
     
     // now set the timestamp
     DateFormat formatter = 
-      new SimpleDateFormat("dd-MMM-YYYY-hh'H'-mm'M'-ss'S'");
+      new SimpleDateFormat("dd-MMM-yyyy-hh'H'-mm'M'-ss'S'");
     Calendar calendar = Calendar.getInstance();
     calendar.setTimeInMillis(System.currentTimeMillis());
     timeStamp = formatter.format(calendar.getTime());


### PR DESCRIPTION
Week year is intended to be used for week dates, eg 2015-W01-1, it is often mistakenly used for calendar dates, in which case the year may be incorrect during the last week of the year 


[_Created by Sourcegraph campaign `christine/fix-misused-weekyear`._](https://demo.sourcegraph.com/users/christine/campaigns/fix-misused-weekyear)